### PR TITLE
[wip] add support for `bool` params

### DIFF
--- a/example/toyapi.dart
+++ b/example/toyapi.dart
@@ -78,6 +78,22 @@ class ToyApi {
     return new ToyResponse()..result = 'Hello ${name} of age ${age}!';
   }
 
+  @ApiMethod(path: 'hero/{name}/{isHero}')
+  ToyResponse helloHeroWithBoolean(String name, bool isHero, {bool fromComics}) {
+    String isHeroString;
+    if(isHero){
+      isHeroString = "you are a hero";
+
+      if(fromComics != null && fromComics){
+        isHeroString = "${isHeroString} from comics";
+      }
+    }else{
+      isHeroString = "you are not a hero";
+    }
+    String response = "Hello ${name} ${isHeroString}";
+    return new ToyResponse()..result = response;
+  }
+
   @ApiMethod(path: 'helloPost', method: 'POST')
   ToyResponse helloPost(ToyRequest request) {
     return new ToyResponse()

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -111,9 +111,14 @@ class ParsedHttpApiRequest {
 /// Helper class describing a method parameter.
 class ApiParameter {
   final String name;
-  final Symbol symbol;
-  final bool isInt;
+  Symbol symbol;
+  bool isInt;
+  bool isBool;
 
-  ApiParameter(this.name, ParameterMirror pm)
-      : this.symbol = pm.simpleName, isInt = pm.type == reflectType(int);
+  ApiParameter(this.name, ParameterMirror pm) {
+    this.symbol = pm.simpleName;
+    isInt = pm.type == reflectType(int);
+    isBool = pm.type == reflectType(bool);
+  }
+
 }

--- a/lib/src/config/method.dart
+++ b/lib/src/config/method.dart
@@ -98,14 +98,7 @@ class ApiConfigMethod {
                                   '${error.toString()}'), stack: stack);
         }
       } else if(param.isBool){
-        try {
           positionalParams.add(value == 'true');
-        } on FormatException catch (error, stack) {
-          return httpErrorResponse(request.originalRequest,
-          new BadRequestError('Invalid bool value: $value for '
-          'path parameter: ${param.name}. '
-          '${error.toString()}'), stack: stack);
-        }
       } else {
         positionalParams.add(value);
       }
@@ -128,14 +121,7 @@ class ApiConfigMethod {
                                       '${error.toString()}'), stack: stack);
             }
           } else if(param.isBool){
-            try {
               namedParams[param.symbol] = value == 'true';
-            } on FormatException catch (error, stack) {
-              return httpErrorResponse(request.originalRequest,
-              new BadRequestError('Invalid bool value: $value for '
-              'query parameter: ${param.name}. '
-              '${error.toString()}'), stack: stack);
-            }
           } else {
             namedParams[param.symbol] = value;
           }

--- a/lib/src/config/method.dart
+++ b/lib/src/config/method.dart
@@ -47,7 +47,7 @@ class ApiConfigMethod {
     _pathParams.forEach((param) {
       var schema = new discovery.JsonSchema();
       schema..type = param.isInt ? discovery.JsonSchema.PARAM_INTEGER_TYPE
-                                 : discovery.JsonSchema.PARAM_STRING_TYPE
+                                 : (param.isBool ? discovery.JsonSchema.PARAM_BOOL_TYPE : discovery.JsonSchema.PARAM_STRING_TYPE)
             ..required = true
             ..description = 'Path parameter: \'${param.name}\'.'
             ..location = discovery.JsonSchema.PARAM_LOCATION_PATH;
@@ -57,7 +57,7 @@ class ApiConfigMethod {
       _queryParams.forEach((param) {
         var schema = new discovery.JsonSchema();
         schema..type = param.isInt ? discovery.JsonSchema.PARAM_INTEGER_TYPE
-                                   : discovery.JsonSchema.PARAM_STRING_TYPE
+                                   : (param.isBool ? discovery.JsonSchema.PARAM_BOOL_TYPE : discovery.JsonSchema.PARAM_STRING_TYPE)
               ..required = false
               ..description = 'Query parameter: \'${param.name}\'.'
               ..location = discovery.JsonSchema.PARAM_LOCATION_QUERY;
@@ -97,6 +97,15 @@ class ApiConfigMethod {
                                   'path parameter: ${param.name}. '
                                   '${error.toString()}'), stack: stack);
         }
+      } else if(param.isBool){
+        try {
+          positionalParams.add(value == 'true');
+        } on FormatException catch (error, stack) {
+          return httpErrorResponse(request.originalRequest,
+          new BadRequestError('Invalid bool value: $value for '
+          'path parameter: ${param.name}. '
+          '${error.toString()}'), stack: stack);
+        }
       } else {
         positionalParams.add(value);
       }
@@ -117,6 +126,15 @@ class ApiConfigMethod {
                   new BadRequestError('Invalid integer value: $value for '
                                       'query parameter: ${param.name}. '
                                       '${error.toString()}'), stack: stack);
+            }
+          } else if(param.isBool){
+            try {
+              namedParams[param.symbol] = value == 'true';
+            } on FormatException catch (error, stack) {
+              return httpErrorResponse(request.originalRequest,
+              new BadRequestError('Invalid bool value: $value for '
+              'query parameter: ${param.name}. '
+              '${error.toString()}'), stack: stack);
             }
           } else {
             namedParams[param.symbol] = value;

--- a/lib/src/discovery/config.dart
+++ b/lib/src/discovery/config.dart
@@ -108,6 +108,9 @@ class JsonSchema {
   /** Used to describe parameters of type int. */
   static const PARAM_INTEGER_TYPE = 'integer';
 
+  /** Used to describe parameters of type bool */
+  static const PARAM_BOOL_TYPE = 'boolean';
+
   /* Used to describe parameters of type string. */
   static const PARAM_STRING_TYPE  = 'string';
 

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -312,9 +312,9 @@ class ApiParser {
       if (pm.isOptional || pm.isNamed) {
         addError('No support for optional path parameters in API methods.');
       }
-      if (pm.type.simpleName != #int && pm.type.simpleName != #String) {
+      if (pm.type.simpleName != #int && pm.type.simpleName != #String && pm.type.simpleName != #bool) {
         addError(
-            'Path parameter \'$pathParamName\' must be of type int or String.');
+            'Path parameter \'$pathParamName\' must be of type int, String or bool.');
       }
       pathParams.add(new ApiParameter(pathParamName, pm));
     }
@@ -335,9 +335,9 @@ class ApiParser {
         addError(
             'Non-path parameter \'$paramName\' must be a named parameter.');
       }
-      if (pm.type.simpleName != #int && pm.type.simpleName != #String) {
+      if (pm.type.simpleName != #int && pm.type.simpleName != #String && pm.type.simpleName != #bool) {
         addError(
-            'Query parameter \'$paramName\' must be of type int or String.');
+            'Query parameter \'$paramName\' must be of type int, String or bool.');
       }
       queryParams.add(new ApiParameter(paramName, pm));
     }


### PR DESCRIPTION
I added support for bool params as well as bool query params.

Work in progress, would like your feedback & need to test if this works with discovery docs.

One thing I have not tested yet is if the document discovery works fine with this. What would be the best way to test this? 

I will also come up with a better example in toyApi.dart lol, I think the "hero" example I have is kinda dumb.



ref: https://github.com/dart-lang/rpc/issues/43