### PR TITLE
Rfc7232 specs restrictions on 204, 304 statuses

### DIFF
--- a/lib/src/config/method.dart
+++ b/lib/src/config/method.dart
@@ -250,8 +250,9 @@ class ApiConfigMethod {
                 context.requestHeaders[HttpHeaders.IF_MODIFIED_SINCE]);
             if (ifModifiedSince != null &&
                 !apiResult.updated.isAfter(ifModifiedSince)) {
+              context.responseHeaders.remove(HttpHeaders.CONTENT_TYPE);
               return new HttpApiResponse(HttpStatus.NOT_MODIFIED,
-                  new Stream.empty(), context.responseHeaders);
+                  null, context.responseHeaders);
             }
           }
         }
@@ -259,8 +260,7 @@ class ApiConfigMethod {
         resultBody = new Stream.fromIterable([resultAsBytes]);
         statusCode = HttpStatus.OK;
       } else {
-        // Return an empty stream.
-        resultBody = new Stream.fromIterable([]);
+        resultBody = null;
         statusCode = HttpStatus.NO_CONTENT;
       }
       // If the api method has set a specific response status code use that

--- a/test/src/invocation/invoke_test.dart
+++ b/test/src/invocation/invoke_test.dart
@@ -322,6 +322,7 @@ main() async {
     test('simple', () async {
       HttpApiResponse response = await _sendRequest('GET', 'get/simple');
       expect(response.status, HttpStatus.NO_CONTENT);
+      expect(response.body, null);
     });
 
     test('throwing', () async {
@@ -523,11 +524,10 @@ main() async {
         HttpHeaders.IF_MODIFIED_SINCE: formatHttpDate(file.lastModifiedSync())
       });
       expect(response.status, HttpStatus.NOT_MODIFIED);
-      expect(response.headers[HttpHeaders.CONTENT_TYPE], 'image/png');
+      expect(response.headers[HttpHeaders.CONTENT_TYPE], null);
       expect(response.headers[HttpHeaders.LAST_MODIFIED],
           formatHttpDate(file.lastModifiedSync()));
-      final bytes = await response.body.toList();
-      expect(bytes.isEmpty, true);
+      expect(response.body, null);
     });
 
     test('get-blob-extra', () async {
@@ -573,6 +573,7 @@ main() async {
     test('simple', () async {
       HttpApiResponse response = await _sendRequest('DELETE', 'delete/simple');
       expect(response.status, HttpStatus.NO_CONTENT);
+      expect(response.body, null);
     });
   });
 


### PR DESCRIPTION
Need to respond with a null body for 204, 304 statuses (based on RFC7232 specs)

As defined in HTTP/1.1 RFC:
> All 1xx (Informational), 204 (No Content), and 304 (Not Modified) responses do not include a message body.  All other responses do include a message body, although the body might be of zero length.

dart:rpc fails the specs on 204, 304 responses.

Biggest impact on failure are http clients that 'try to' enforce strict http/1.0, 1.1 specification, like the [Google Api .net client](https://github.com/google/google-api-dotnet-client) where a dart rpc server can fail on consecutive-even delete requests (every 2nd, 4th and so on) with the following exception:

```
An error occurred while sending the request.

System.Net.WebException	{"The server committed a protocol violation. Section=ResponseStatusLine"}
	System.Net.WebException
   at System.Net.HttpWebRequest.EndGetResponse(IAsyncResult asyncResult)
   at System.Net.Http.HttpClientHandler.GetResponseCallback(IAsyncResult ar)
   
Source	"Google.Apis"
StackTrace	"   at Google.Apis.Requests.ClientServiceRequest`1.Execute() in
C:\Apiary\v1_19\google-api-dotnet-client\Src\Support\GoogleApis\Apis\Requests\ClientServiceRequest.cs:line 102
     at ApisTesting.LocalApiTests.TestWritesUpdates(Int32 repeats) in D:\ApiTesting\ApisTesting\ApiTests.vb:line 49"
```
