### PR TITLE
Custom serializer

### DIFF
--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -232,8 +232,15 @@ class ClientApiGenerator {
     try {
       await Isolate.spawn(
           _isolateTrampoline,
-          [uri, _apiFilePath, cmd, _apiPort, _apiPrefix,
-          messagePort.sendPort, errorPort.sendPort],
+          [
+            uri,
+            _apiFilePath,
+            cmd,
+            _apiPort,
+            _apiPrefix,
+            messagePort.sendPort,
+            errorPort.sendPort
+          ],
           onError: errorPort.sendPort);
     } catch (error) {
       closePorts();
@@ -254,6 +261,7 @@ class ClientApiGenerator {
         completer.complete(value);
       }
     }
+
     messageSubscription = messagePort.listen((value) {
       finish(value, false);
     });
@@ -296,10 +304,8 @@ class ClientApiGenerator {
     SendPort messagePort = args[5];
     SendPort errorPort = args[6];
     return await Isolate.spawnUri(
-      Uri.parse(args[0]),
-      [args[1], args[2], args[3], args[4]],
-      messagePort,
-      onError: errorPort);
+        Uri.parse(args[0]), [args[1], args[2], args[3], args[4]], messagePort,
+        onError: errorPort);
   }
 
   String get generatorSource {

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -64,7 +64,16 @@ class ApiMethod {
   /// Description of the method.
   final String description;
 
-  const ApiMethod({this.name, this.path, this.method: 'GET', this.description});
+  /// An optional serializer to use for encoding respose.
+  /// it avoid to have to fully describe the response
+  final dynamic serializer;
+
+  const ApiMethod(
+      {this.name,
+      this.path,
+      this.method: 'GET',
+      this.description,
+      this.serializer});
 }
 
 /// Optional annotation for parameters inside of API request/response messages.
@@ -107,6 +116,10 @@ class ApiProperty {
   /// For int properties: the maximal value.
   final int maxValue;
 
+  /// An optional serializer to use for encoding the response.
+  /// it avoid to have to fully describe the reponse
+  final dynamic serializer;
+
   /// Possible values for enum properties, as value - description pairs.
   ///  Properties using this will have to be String.
   final Map<String, String> values;
@@ -118,6 +131,7 @@ class ApiProperty {
       this.required: false,
       this.ignore: false,
       this.defaultValue,
+      this.serializer: null,
       this.minValue,
       this.maxValue,
       this.values});

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -99,8 +99,10 @@ class ParsedHttpApiRequest {
     if (request.headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
       final header = request.headers[HttpHeaders.CONTENT_TYPE];
 
-      if (header is List) contentType = ContentType.parse(header.join(' '));
-      else contentType = ContentType.parse(header);
+      if (header is List)
+        contentType = ContentType.parse(header.join(' '));
+      else
+        contentType = ContentType.parse(header);
     }
     return new ParsedHttpApiRequest._(request, apiKey, isOptions, methodKey,
         methodUri, jsonToBytes, contentType);

--- a/lib/src/config/property.dart
+++ b/lib/src/config/property.dart
@@ -310,9 +310,10 @@ class ListProperty extends ApiConfigSchemaProperty {
 
 class MapProperty extends ApiConfigSchemaProperty {
   final ApiConfigSchemaProperty _additionalProperty;
+  final dynamic serializer;
 
-  MapProperty(
-      String name, String description, bool required, this._additionalProperty)
+  MapProperty(String name, String description, bool required,
+      this._additionalProperty, this.serializer)
       : super(name, description, required, null, null, null);
 
   discovery.JsonSchema get typeAsDiscovery =>
@@ -325,6 +326,11 @@ class MapProperty extends ApiConfigSchemaProperty {
     if (mapObject is! Map) {
       throw new BadRequestError('Invalid property, should be of type \'Map\'');
     }
+
+    if (serializer != null) {
+      return serializer(mapObject);
+    }
+
     var result = {};
     (mapObject as Map).forEach((String key, object) {
       result[key] = _additionalProperty.toResponse(object);

--- a/lib/src/config/schema.dart
+++ b/lib/src/config/schema.dart
@@ -56,9 +56,7 @@ class ApiConfigSchema {
           // If in form, there is an (input[type="file"] multiple) and the user
           // put only one file. It's not an error and it should be accept.
           // Maybe it cans be optimized.
-          if (schema.type.instanceMembers[sym]
-                      .returnType
-                      .reflectedType
+          if (schema.type.instanceMembers[sym].returnType.reflectedType
                       .toString() ==
                   'List<MediaMessage>' &&
               request[prop.name] is MediaMessage) {

--- a/lib/src/http_body_parser.dart
+++ b/lib/src/http_body_parser.dart
@@ -50,42 +50,46 @@ Future<PostData> _asFormData(ParsedHttpApiRequest request) {
           new MimeMultipartTransformer(contentType.parameters['boundary']))
       .map(_HttpMultipartFormData.parse)
       .map((_HttpMultipartFormData multipart) {
-    Future future;
-    if (multipart.isText) {
-      future = multipart
-          .fold(new StringBuffer(), _fillStringBuffer)
-          .then((StringBuffer buffer) => buffer.toString());
-    } else {
-      future = multipart
-          .fold(new BytesBuilder(), _fillBytesBuilder)
-          .then((BytesBuilder builder) => builder.takeBytes());
-    }
-    return future.then((dynamic data) {
-      final String filename =
-          multipart.contentDisposition.parameters['filename'];
-      if (filename != null) {
-        if (multipart.isText) data = (data as String).codeUnits;
-        data = new MediaMessage()
-          ..contentType = multipart.contentType.value
-          ..bytes = data
-          ..metadata = {'filename': filename};
-      }
-      return [multipart.contentDisposition.parameters['name'], data];
-    });
-  }).fold([],
+        Future future;
+        if (multipart.isText) {
+          future = multipart
+              .fold(new StringBuffer(), _fillStringBuffer)
+              .then((StringBuffer buffer) => buffer.toString());
+        } else {
+          future = multipart
+              .fold(new BytesBuilder(), _fillBytesBuilder)
+              .then((BytesBuilder builder) => builder.takeBytes());
+        }
+        return future.then((dynamic data) {
+          final String filename =
+              multipart.contentDisposition.parameters['filename'];
+          if (filename != null) {
+            if (multipart.isText) data = (data as String).codeUnits;
+            data = new MediaMessage()
+              ..contentType = multipart.contentType.value
+              ..bytes = data
+              ..metadata = {'filename': filename};
+          }
+          return [multipart.contentDisposition.parameters['name'], data];
+        });
+      })
+      .fold([],
           (List<Future> futureList, Future future) => futureList..add(future))
       .then(Future.wait)
       .then((List<List> parts) {
-    Map<String, dynamic> map = {};
-    // Form input file multiple
-    for (var part in parts) {
-      if (map[part[0]] != null) {
-        if (map[part[0]] is List) map[part[0]].add(part[1]);
-        else map[part[0]] = [map[part[0]], part[1]];
-      } else map[part[0]] = part[1];
-    }
-    return new PostData('form', map);
-  });
+        Map<String, dynamic> map = {};
+        // Form input file multiple
+        for (var part in parts) {
+          if (map[part[0]] != null) {
+            if (map[part[0]] is List)
+              map[part[0]].add(part[1]);
+            else
+              map[part[0]] = [map[part[0]], part[1]];
+          } else
+            map[part[0]] = part[1];
+        }
+        return new PostData('form', map);
+      });
 }
 
 Future<PostData> parseRequestBody(ParsedHttpApiRequest request) {
@@ -163,8 +167,9 @@ class _HttpMultipartFormData extends Stream {
           break;
       }
     }
-    if (disposition == null) throw new HttpException(
-        "Mime Multipart doesn't contain a Content-Disposition header value");
+    if (disposition == null)
+      throw new HttpException(
+          "Mime Multipart doesn't contain a Content-Disposition header value");
     return new _HttpMultipartFormData(
         type, disposition, encoding, multipart, UTF8);
   }
@@ -177,9 +182,9 @@ class _HttpMultipartFormData extends Stream {
       Encoding defaultEncoding) {
     _stream = _mimeMultipart;
 
-    if (contentTransferEncoding !=
-        null) throw new HttpException("Unsupported contentTransferEncoding: "
-        "${contentTransferEncoding.value}");
+    if (contentTransferEncoding != null)
+      throw new HttpException("Unsupported contentTransferEncoding: "
+          "${contentTransferEncoding.value}");
 
     if (contentType == null ||
         contentType.primaryType == 'text' ||

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -273,6 +273,7 @@ class ApiParser {
 
     // Parse method return type.
     var responseSchema = _parseMethodReturnType(mm);
+    var serializer = metadata.serializer;
 
     var methodConfig = new ApiConfigMethod(
         discoveryId,
@@ -286,7 +287,8 @@ class ApiParser {
         queryParams,
         requestSchema,
         responseSchema,
-        parser);
+        parser,
+        serializer);
 
     _setupApiMethod(methodConfig);
 
@@ -644,7 +646,6 @@ class ApiParser {
   // Runs through all fields on a schema class and parses them accordingly.
   Map<Symbol, ApiConfigSchemaProperty> _parseProperties(
       ClassMirror schemaClass, bool isRequest) {
-
     // Figure out if we've got the annotation to include the parent class
     bool includeSuperClass = false;
     for (InstanceMirror im in schemaClass.metadata) {
@@ -668,6 +669,7 @@ class ApiParser {
       if (propertyName == null) {
         propertyName = MirrorSystem.getName(vm.simpleName);
       }
+
       var property = parseProperty(vm.type, propertyName, metadata, isRequest);
       if (property != null) {
         properties[vm.simpleName] = property;
@@ -964,7 +966,7 @@ class ApiParser {
     var additionalProperty = parseProperty(
         mapTypeArguments[1], propertyName, new ApiProperty(), isRequest);
     return new MapProperty(propertyName, metadata.description,
-        metadata.required, additionalProperty);
+        metadata.required, additionalProperty, metadata.serializer);
   }
 
   // Helper method to check that a field annotated with an ApiProperty is using
@@ -976,7 +978,8 @@ class ApiParser {
       #name,
       #description,
       #required,
-      #ignore
+      #ignore,
+      #serializer
     ];
     InstanceMirror im = reflect(metadata);
     im.type.declarations.forEach((Symbol field, DeclarationMirror fieldMirror) {

--- a/test/api_config_test.dart
+++ b/test/api_config_test.dart
@@ -376,6 +376,14 @@ void main() {
           'parameterOrder': ['count'],
           'request': {'\$ref': 'TestMessage1'},
           'response': {'\$ref': 'TestMessage1'}
+        },
+        'customQuery': {
+          'id': 'CorrectMethods.customQuery',
+          'path': 'customQuery',
+          'httpMethod': 'GET',
+          'parameters': {},
+          'parameterOrder': [],
+          'response': {'\$ref': 'ListOfObject'}
         }
       };
       expect(json['methods'], expectedJsonMethods);

--- a/test/api_config_test.dart
+++ b/test/api_config_test.dart
@@ -621,31 +621,23 @@ void main() {
     });
 
     test('recursion', () {
-      expect(
-          new Future.sync(() {
-            var parser = new ApiParser();
-            parser.parseSchema(reflectClass(RecursiveMessage1), true);
-          }),
-          completes);
-      expect(
-          new Future.sync(() {
-            var parser = new ApiParser();
-            parser.parseSchema(reflectClass(RecursiveMessage2), true);
-          }),
-          completes);
-      expect(
-          new Future.sync(() {
-            var parser = new ApiParser();
-            parser.parseSchema(reflectClass(RecursiveMessage3), true);
-          }),
-          completes);
-      expect(
-          new Future.sync(() {
-            var parser = new ApiParser();
-            parser.parseSchema(reflectClass(RecursiveMessage2), true);
-            parser.parseSchema(reflectClass(RecursiveMessage3), true);
-          }),
-          completes);
+      expect(new Future.sync(() {
+        var parser = new ApiParser();
+        parser.parseSchema(reflectClass(RecursiveMessage1), true);
+      }), completes);
+      expect(new Future.sync(() {
+        var parser = new ApiParser();
+        parser.parseSchema(reflectClass(RecursiveMessage2), true);
+      }), completes);
+      expect(new Future.sync(() {
+        var parser = new ApiParser();
+        parser.parseSchema(reflectClass(RecursiveMessage3), true);
+      }), completes);
+      expect(new Future.sync(() {
+        var parser = new ApiParser();
+        parser.parseSchema(reflectClass(RecursiveMessage2), true);
+        parser.parseSchema(reflectClass(RecursiveMessage3), true);
+      }), completes);
     });
 
     test('variants', () {

--- a/test/src/generator/generator_test.dart
+++ b/test/src/generator/generator_test.dart
@@ -31,7 +31,8 @@ main() {
   // file.
   void setupPackage({bool addPubSpec: true}) {
     assert(packagePath == null);
-    packagePath = Directory.systemTemp.createTempSync('rpc_generator_tests').path;
+    packagePath =
+        Directory.systemTemp.createTempSync('rpc_generator_tests').path;
     new Directory(join(absolute(packagePath), 'lib')).createSync();
     if (addPubSpec) {
       new File(join(dataPath, 'pubspec.yamll'))

--- a/test/src/invocation/invoke_test.dart
+++ b/test/src/invocation/invoke_test.dart
@@ -23,6 +23,11 @@ File _blobFile() {
   return new File(blobPath);
 }
 
+identiy(x) {
+  print("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx $x");
+  return x;
+}
+
 // Tests for exercising the setting of default values
 class DefaultValueMessage {
   @ApiProperty(defaultValue: 5)
@@ -212,6 +217,14 @@ class GetAPI {
     return new InheritanceChildClassBaseExcluded()
       ..stringFromBase = 'From base'
       ..stringFromChild = 'From child';
+  }
+
+  @ApiMethod(path: 'json/{name}/{value}', serializer: identiy)
+  Object getJson(String name, String value) {
+    var result = {};
+    result[name] = value;
+
+    return result;
   }
 }
 
@@ -540,7 +553,17 @@ main() async {
       expect(blob['metadata'], {'description': 'logo'});
       expect(blob['md5Hash'], 'a675cb93b75d5f1656c920dceecdcb38');
     });
-
+    test('json', () async {
+      print('hi');
+      HttpApiResponse response = await _sendRequest('GET', 'json/city/cannes');
+      expect(response.status, HttpStatus.OK);
+      var result = await _decodeBody(response.body);
+      expect(result, {'city': 'cannes'});
+      response = await _sendRequest('GET', 'json/name/david');
+      expect(response.status, HttpStatus.OK);
+      result = await _decodeBody(response.body);
+      expect(result, {'name': 'david'});
+    });
     test('get-inherited-child-class-base-included', () async {
       HttpApiResponse response =
           await _sendRequest('GET', 'get/inheritanceChildClassBaseIncluded');
@@ -732,7 +755,7 @@ main() async {
       var result = await _decodeBody(response.body);
       var expectedResult = {
         'kind': 'discovery#restDescription',
-        'etag': 'b84bbbc4efcd363eccdc86066621cc34bdb49e1c',
+        'etag': 'c185c3643b8dfd3deb983628b0314c541b4c0d3c',
         'discoveryVersion': 'v1',
         'id': 'testAPI:v1',
         'name': 'testAPI',
@@ -993,6 +1016,26 @@ main() async {
                 'parameterOrder': [],
                 'response': {r'$ref': 'MediaMessage'},
                 'supportsMediaDownload': true
+              },
+              'getJson': {
+                'id': 'TestAPI.get.getJson',
+                'path': 'json/{name}/{value}',
+                'httpMethod': 'GET',
+                'parameters': {
+                  'name': {
+                    'type': 'string',
+                    'description': 'Path parameter: \'name\'.',
+                    'required': true,
+                    'location': 'path'
+                  },
+                  'value': {
+                    'type': 'string',
+                    'description': 'Path parameter: \'value\'.',
+                    'required': true,
+                    'location': 'path'
+                  }
+                },
+                'parameterOrder': ['name', 'value']
               },
               'getInheritanceChildClassBaseIncluded': {
                 'id': 'TestAPI.get.getInheritanceChildClassBaseIncluded',

--- a/test/src/invocation/invoke_test.dart
+++ b/test/src/invocation/invoke_test.dart
@@ -213,7 +213,6 @@ class GetAPI {
       ..stringFromBase = 'From base'
       ..stringFromChild = 'From child';
   }
-
 }
 
 class DeleteAPI {
@@ -262,7 +261,6 @@ class PostAPI {
     context.responseHeaders['my-Own-header'] = 'aHeaderValue';
     return message;
   }
-
 
   @ApiMethod(method: 'POST', path: 'post/inheritanceChildClassBaseIncluded')
   InheritanceChildClassBaseIncluded inheritanceChildClassBaseIncludedPost(
@@ -364,8 +362,7 @@ main() async {
       expect(response.status, HttpStatus.OK);
       var result = await _decodeBody(response.body);
       expect(result, {'aString': 'Hello Ghost'});
-      response =
-          await _sendRequest('GET', 'get/hello', query: '?name=John');
+      response = await _sendRequest('GET', 'get/hello', query: '?name=John');
       expect(response.status, HttpStatus.OK);
       result = await _decodeBody(response.body);
       expect(result, {'aString': 'Hello John'});
@@ -384,8 +381,7 @@ main() async {
     });
 
     test('hello-path', () async {
-      HttpApiResponse response =
-          await _sendRequest('GET', 'get/hello/John');
+      HttpApiResponse response = await _sendRequest('GET', 'get/hello/John');
       expect(response.status, HttpStatus.OK);
       var result = await _decodeBody(response.body);
       expect(result, {'aString': 'Hello John'});
@@ -398,7 +394,6 @@ main() async {
       var result = await _decodeBody(response.body);
       expect(result, {'aString': 'Hello John Cena'});
     });
-
 
     test('minmax', () async {
       HttpApiResponse response = await _sendRequest('GET', 'get/minmax/7');
@@ -518,8 +513,8 @@ main() async {
 
     test('get-blob-media-unmodified', () async {
       final file = _blobFile();
-      HttpApiResponse response =
-          await _sendRequest('GET', 'get/blob', extraHeaders: {
+      HttpApiResponse response = await _sendRequest(
+          'GET', 'get/blob', extraHeaders: {
         HttpHeaders.IF_MODIFIED_SINCE: formatHttpDate(file.lastModifiedSync())
       });
       expect(response.status, HttpStatus.NOT_MODIFIED);
@@ -546,9 +541,9 @@ main() async {
       expect(blob['md5Hash'], 'a675cb93b75d5f1656c920dceecdcb38');
     });
 
-    test('get-inherited-child-class-base-included', () async{
+    test('get-inherited-child-class-base-included', () async {
       HttpApiResponse response =
-      await _sendRequest('GET', 'get/inheritanceChildClassBaseIncluded');
+          await _sendRequest('GET', 'get/inheritanceChildClassBaseIncluded');
       expect(response.status, HttpStatus.OK);
       expect(response.headers[HttpHeaders.CONTENT_TYPE],
           'application/json; charset=utf-8');
@@ -557,16 +552,15 @@ main() async {
           {'stringFromBase': 'From base', 'stringFromChild': 'From child'});
     });
 
-    test('get-inherited-child-class-base-excluded', () async{
+    test('get-inherited-child-class-base-excluded', () async {
       HttpApiResponse response =
-      await _sendRequest('GET', 'get/inheritanceChildClassBaseExcluded');
+          await _sendRequest('GET', 'get/inheritanceChildClassBaseExcluded');
       expect(response.status, HttpStatus.OK);
       expect(response.headers[HttpHeaders.CONTENT_TYPE],
           'application/json; charset=utf-8');
       var result = await _decodeBody(response.body);
       expect(result, {'stringFromChild': 'From child'});
     });
-
   });
 
   group('api-invoke-delete', () {
@@ -666,14 +660,15 @@ main() async {
         'stringFromBase': 'posted string from base',
         'stringFromChild': 'posted string from child'
       };
-      HttpApiResponse response = await _sendRequest('POST',
-          'post/inheritanceChildClassBaseIncluded', body: objectFields);
+      HttpApiResponse response = await _sendRequest(
+          'POST', 'post/inheritanceChildClassBaseIncluded',
+          body: objectFields);
       var resultBody = await _decodeBody(response.body);
       expect(resultBody, objectFields);
     });
     test('add-inheritance-child-class-base-excluded', () async {
-      HttpApiResponse response = await _sendRequest('POST',
-          'post/inheritanceChildClassBaseExcluded',
+      HttpApiResponse response = await _sendRequest(
+          'POST', 'post/inheritanceChildClassBaseExcluded',
           body: {
             // don't expect this in the result...
             'stringFromBase': 'posted string from base',
@@ -814,7 +809,9 @@ main() async {
           'InheritanceChildClassBaseExcluded': {
             'id': 'InheritanceChildClassBaseExcluded',
             'type': 'object',
-            'properties': {'stringFromChild': {'type': 'string'}}
+            'properties': {
+              'stringFromChild': {'type': 'string'}
+            }
           },
           'DefaultValueMessage': {
             'id': 'DefaultValueMessage',

--- a/test/src/test_api.dart
+++ b/test/src/test_api.dart
@@ -212,7 +212,18 @@ class CorrectMethods {
   TestMessage1 method17(int count, TestMessage1 request) {
     return new TestMessage1();
   }
+
+  @ApiMethod(path: 'customQuery', serializer: identity)
+  List<Object> customQuery() {
+    return [
+      1,
+      {"a": 1},
+      2
+    ];
+  }
 }
+
+identity(x) => x;
 
 class NoAnnotation {}
 

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -7,8 +7,8 @@ import 'package:path/path.dart' as p;
 String getPackageDir() {
   // Locate the "test" directory. Use mirrors so that this works with the test
   // package, which loads this suite into an isolate.
-  var testDir = p.dirname(currentMirrorSystem()
-      .findLibrary(#rpc.test.test_util).uri.toFilePath());
+  var testDir = p.dirname(
+      currentMirrorSystem().findLibrary(#rpc.test.test_util).uri.toFilePath());
 
   return p.dirname(testDir);
 }


### PR DESCRIPTION
I have database with query. When you execute a query, it return some bson data (mongodb) that depends on the executed query.
Query can be executed /query/{queryId}/execute API route.
Thus, for this route, the schema cannot be defined in advance and data are not real json.
To handle this situation, I  implemented a `serializer` property for the ApiMethod annotation.
Here is a pull request for this change. If a better solution is possible, I would be happy to use it instead.

Usage example:

```dart
  @ApiMethod(path: 'queries/{id}/execute', serializer: bsonToJson)
  Future<List<Object>> execute(String id) async {
    var query =
        await queryCol.findOne({"_id": new mongo.ObjectId.fromHexString(id)});
    Iterable steps = query["iwe"]["exec-plan"].values;

    var firstQuery = steps.firstWhere((x) => x["type"] == "query")["config"];

    List aggregation = JSON.decode(firstQuery["query"]);

    aggregation.retainWhere((x) => x != "\$secure\$");
    String collection = this.envId + "." + firstQuery["collection"];

    aggregation.insert(0, {"\$limit": 10});
    var results = await db
        .collection(collection)
        .aggregateToStream(aggregation, allowDiskUse: true)
        .toList();

    return results;
  }

dynamic encode(obj) {
  if (obj is DateTime) {
    return {"\$date": obj.toString()};
  }
  if (obj is mongo.ObjectId) {
    return {"\$id": obj.toHexString()};
  }

  return obj;
}

bsonToJson(dynamic data) {
  if (data is Map) {
    var result = {};
    data.forEach((key, value) {
      result[key] = bsonToJson(value);
    });
    return result;
  } 
 if (data is List) {
    return data.map(bsonToJson).toList();
  }
  return encode(data);
}
``` 

