### PR TITLE
Call toDouble in DoubleProperty

### DIFF
--- a/lib/src/config/property.dart
+++ b/lib/src/config/property.dart
@@ -152,7 +152,7 @@ class DoubleProperty extends ApiConfigSchemaProperty {
   _singleRequestValue(value) {
     assert(value != null);
     if (value is num) {
-      return value;
+      return value.toDouble();
     }
     try {
       return double.parse(value);


### PR DESCRIPTION
This prevent to hit an assertion when decoding a double encoded as an integer in the JSON.